### PR TITLE
Expose the StreamInfo MD5

### DIFF
--- a/src/java/org/kc7bfi/jflac/metadata/StreamInfo.java
+++ b/src/java/org/kc7bfi/jflac/metadata/StreamInfo.java
@@ -233,4 +233,10 @@ public class StreamInfo extends Metadata {
     public int getChannels() {
         return channels;
     }
-}
+
+    /**
+     * @return Returns the binary MD5 embedded in the StreamInfo.
+     */
+    public byte[] getMD5sum() {
+        return md5sum;
+    }    }

--- a/src/java/org/kc7bfi/jflac/metadata/StreamInfo.java
+++ b/src/java/org/kc7bfi/jflac/metadata/StreamInfo.java
@@ -239,4 +239,5 @@ public class StreamInfo extends Metadata {
      */
     public byte[] getMD5sum() {
         return md5sum;
-    }    }
+    }    
+}


### PR DESCRIPTION
Hi -  I use the audio MD5 to detect changes to my collection flac/alac files and being able to extract the embedded original MD5 is very useful. 

I added a getter to the StreamInfo class to match the getters for the other properties of the StreamInfo. Please add this change to the main branch (sorry, not really used to the Git jargon, or really sure where this message is going to go even!!)

