### PR TITLE
Update maven compiler pluging to 3.11.0 to avoid use of log4j v1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,9 @@
     </resources>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.11.0</version>
         <configuration>
           <source>1.6</source>
           <target>1.6</target>


### PR DESCRIPTION
Addresses issue #9 